### PR TITLE
Add template files for feedbacks and variables

### DIFF
--- a/feedbacks.js
+++ b/feedbacks.js
@@ -1,0 +1,33 @@
+const { combineRgb } = require('@companion-module/base')
+
+module.exports = async function (self) {
+	self.setFeedbackDefinitions({
+		ChannelState: {
+			name: 'Example Feedback',
+			type: 'boolean',
+			label: 'Channel State',
+			defaultStyle: {
+				bgcolor: combineRgb(255, 0, 0),
+				color: combineRgb(0, 0, 0),
+			},
+			options: [
+				{
+					id: 'num',
+					type: 'number',
+					label: 'Test',
+					default: 5,
+					min: 0,
+					max: 10,
+				},
+			],
+			callback: (feedback) => {
+				console.log('Hello world!', feedback.options.num)
+				if(feedback.options.num > 5) {
+					return true
+				} else {
+					return false
+				}
+			},
+		},
+	})
+}

--- a/main.js
+++ b/main.js
@@ -1,6 +1,8 @@
 const { InstanceBase, Regex, runEntrypoint, InstanceStatus } = require('@companion-module/base')
 const UpgradeScripts = require('./upgrades')
 const UpdateActions = require('./actions')
+const UpdateFeedbacks = require('./feedbacks')
+const UpdateVariableDefinitions = require('./variables')
 
 class ModuleInstance extends InstanceBase {
 	constructor(internal) {
@@ -13,6 +15,8 @@ class ModuleInstance extends InstanceBase {
 		this.updateStatus(InstanceStatus.Ok)
 
 		this.updateActions() // export actions
+		this.updateFeedbacks() // export feedbacks
+		this.updateVariableDefinitions() // export variable definitions
 	}
 	// When module gets deleted
 	async destroy() {
@@ -46,6 +50,15 @@ class ModuleInstance extends InstanceBase {
 	updateActions() {
 		UpdateActions(this)
 	}
+
+	updateFeedbacks() {
+		UpdateFeedbacks(this)
+	}
+
+	updateVariableDefinitions() {
+		UpdateVariableDefinitions(this)
+	}
+	
 }
 
 runEntrypoint(ModuleInstance, UpgradeScripts)

--- a/variables.js
+++ b/variables.js
@@ -1,0 +1,7 @@
+module.exports = async function (self) {
+	self.setVariableDefinitions([
+		{ variableId: 'variable1', name: 'My first variable' },
+		{ variableId: 'variable2', name: 'My second variable' },
+		{ variableId: 'variable3', name: 'Another variable' },
+	])
+}


### PR DESCRIPTION
Adds a template variables and feedbacks file for developers to utilize. (Mentioned in companion-module-base as pointed out here [companion-module-base #34](https://github.com/bitfocus/companion-module-base/issues/34#issue-1510167873))